### PR TITLE
encoder optimization pass

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,14 @@ project(simple_ans VERSION 0.1.0 LANGUAGES CXX)
 # Find pybind11
 find_package(pybind11 REQUIRED)
 
+include(FetchContent)
+FetchContent_Declare(
+  unordered_dense
+  GIT_REPOSITORY https://github.com/martinus/unordered_dense.git
+  GIT_TAG v4.5.0
+  GIT_SHALLOW TRUE)
+FetchContent_MakeAvailable(unordered_dense)
+
 # Set C++ standard
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -28,6 +36,7 @@ target_include_directories(_simple_ans
     PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}/simple_ans/cpp
 )
+target_link_libraries(_simple_ans PRIVATE unordered_dense)
 
 # Set compiler flags
 if(MSVC)


### PR DESCRIPTION
This PR attempts to optimize the encoder using various 'low hanging' techniques. I'd like to do some further investigation, but the following two optimizations considerably speed things up, as one of the main bottlenecks is looking up the symbol index. To alleviate this I have altered the implementation in two major ways

1. Swap out the map implementation with https://github.com/martinus/unordered_dense. This map resulted in an ~25% increase in throughput in most of the basic tests
2. Use a flat array for lookups when the domain of the symbol values is narrow. I.e. `max(symbols) - min(symbols) + 1 <= 4096`. This threshold could, and probably should, be increased, but I wanted to get a proof of concept out there and open up the discussion. This optimization roughly doubled the encoding throughput in the given benchmarks (which live on a very small domain). I have no idea what the typical use case for this algorithm is, so I'm not sure how often this optimization will trigger.